### PR TITLE
ci: build package in weekly verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,7 @@ jobs:
 
       - name: Test
         run: uv run pytest -q
+
+      # A green test suite does not prove the wheel and source archive can be produced.
+      - name: Build package
+        run: uv build

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,10 +2,11 @@
 
 ## Current State
 
-- Working branch: `docs/maintenance-cleanup` (the repository default is `main`)
+- Working branch: `ci/weekly-build` (the repository default is `main`)
 - Remote: `git@github.com:dragonfoxsl/os-download.git`
 - Current package version: `0.1.3`
-- CI runs on push, pull request, manual dispatch, and Fridays at `03:00 UTC`.
+- CI runs lint, tests, and a package build on push, pull request, manual dispatch,
+  and Fridays at `03:00 UTC`.
 - Dependabot checks `uv` and GitHub Actions weekly on Friday.
 
 ## Maintainer Rules

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ Get the README right *before* tagging: the PyPI project page is baked in at uplo
 
 ## Maintenance Expectations
 
-Repository automation runs CI and Dependabot checks every Friday, with manual
-workflow runs available in GitHub Actions. For every change, keep `README.md`
+Repository automation runs lint, tests, a package build, and Dependabot checks
+every Friday, with manual workflow runs available in GitHub Actions. For every change, keep `README.md`
 and `HANDOFF.md` current, follow secure development practices, add concise
 comments where logic is not obvious, and keep code and configuration files
 under 1000 lines and normal documentation under 2000 lines.


### PR DESCRIPTION
## Summary
- build the source distribution and wheel in the existing weekly CI run
- retain the current Friday 03:00 UTC schedule
- document package-build coverage in the maintainer guidance

## Why
A passing test suite does not prove that release artifacts can be produced. This gives the maintenance automation a fresh packaging result before it evaluates the repository.

## Verification
- `uv run ruff check`
- `uv run pytest -q` — 74 passed, 2 skipped
- `uv build` — source archive and wheel built successfully
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Safety / rollback
No publishing behavior or credentials change. Revert this PR to remove the additional package-build step.