### PR TITLE
chore(release): prepare 0.1.4 README cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@
 - Keep code, tests, workflows, and configuration files under 1000 lines. Normal documentation files may grow to 2000 lines; split documentation before it exceeds that limit.
 - Add concise comments for non-obvious security, network, checksum, retry, or platform-specific logic. Avoid comments that restate the code.
 - Update `README.md` with every user-facing, operational, setup, security, or workflow change.
-- For future README creation or major rewrites, follow this repository's README style: visual header/badges when relevant, concise product summary, clear command blocks, practical tables, maintenance expectations near the end, and license at the end.
+- For future README creation or major rewrites, follow this repository's public README style: visual header/badges when relevant, concise product summary, clear command blocks, practical tables, and license at the end.
+- Keep agent instructions, branch state, dated PR lists, and operational handoff notes out of `README.md`; put them in `HANDOFF.md` or `AGENTS.md`.
 - Ko-fi/support sections are optional. Preserve existing ones, but do not add new Ko-fi or donation content unless the user explicitly requests it.
 - Update `HANDOFF.md` with each change so the next maintainer can see what changed, how it was verified, and what remains.
 - Before committing, run the relevant tests, builds, audits, and `git diff --check`. Before pushing, if GitHub Actions or Dependabot are configured, check for CI failures and open Dependabot alerts or failing dependency PRs.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,9 +2,9 @@
 
 ## Current State
 
-- Working branch: `ci/weekly-build` (the repository default is `main`)
+- Working branch: `docs/public-readme-cleanup` (the repository default is `main`)
 - Remote: `git@github.com:dragonfoxsl/os-download.git`
-- Current package version: `0.1.3`
+- Current package version: `0.1.4`
 - CI runs lint, tests, and a package build on push, pull request, manual dispatch,
   and Fridays at `03:00 UTC`.
 - Dependabot checks `uv` and GitHub Actions weekly on Friday.
@@ -13,7 +13,9 @@
 
 - Never add AI co-author trailers to commits.
 - Keep `README.md` and this `HANDOFF.md` updated with each change.
-- Preserve this repository's README style for future README creation or major rewrites.
+- Keep public README content focused on users and contributors. Put agent instructions,
+  branch state, dated PR lists, and operational handoff notes in `HANDOFF.md` or `AGENTS.md`.
+- Preserve this repository's public README style for future README creation or major rewrites.
 - Preserve existing support links, but do not add new Ko-fi/donation content unless explicitly requested.
 - Follow secure development practices for download URLs, checksum verification, subprocess use, and GitHub Actions.
 - Keep code and configuration files under 1000 lines, and normal documentation under 2000 lines.
@@ -29,10 +31,9 @@
 
 ## Open Items
 
-- Dependabot audit (2026-07-24): no open security alerts. Two update PRs
-  remain open: #3 (five grouped GitHub Actions updates) and #8 (`ruff`
-  0.15.18 → 0.16.0). Both PRs currently have green Python 3.10 and 3.13 CI.
+- Dependabot audit (2026-07-25): no open version-update PRs.
 - `uv.lock` was refreshed on 2026-07-23 for patched `idna`, `requests`, and
   `urllib3`; release `v0.1.3` includes that lock update.
+- The upcoming `v0.1.4` release will republish the corrected README metadata to PyPI.
 - Keep README screenshots/help output aligned before release tags.
 - Recheck finder modules when upstream distro download pages change.

--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ Pushing a `vX.Y.Z` tag publishes to PyPI. The workflow authenticates with a [Tru
 
 ```bash
 # 1. Bump the version in BOTH places — the workflow aborts if the tag does not match
-#    pyproject.toml            version = "0.1.3"
-#    src/os_download/__init__.py   __version__ = "0.1.3"
+#    pyproject.toml            version = "0.1.4"
+#    src/os_download/__init__.py   __version__ = "0.1.4"
 
 # 2. Update the README for anything user-facing (flags, defaults, behaviour), and
 #    regenerate the screenshots if the CLI or dashboard changed
@@ -364,7 +364,7 @@ node scripts/svg2png.mjs
 uv run ruff check && uv run pytest -q && uv build
 
 # 4. Tag and push
-git tag -a v0.1.3 -m "os-download 0.1.3" && git push origin v0.1.3
+git tag -a v0.1.4 -m "os-download 0.1.4" && git push origin v0.1.4
 ```
 
 Get the README right *before* tagging: the PyPI project page is baked in at upload time, so a later README fix will not appear there without a new release. A published version can be yanked but never re-uploaded.
@@ -376,24 +376,6 @@ Get the README right *before* tagging: the PyPI project page is baked in at uplo
 | Project | Role |
 |---|---|
 | [Mido](https://github.com/ElliotKillick/Mido) by [@ElliotKillick](https://github.com/ElliotKillick) | Windows 11 ISO download — Mido replicates Microsoft's JavaScript session-token flow to deliver a direct ISO. os-download clones and invokes it automatically. |
-
----
-
-## Maintenance Expectations
-
-Repository automation runs lint, tests, a package build, and Dependabot checks
-every Friday, with manual workflow runs available in GitHub Actions. For every change, keep `README.md`
-and `HANDOFF.md` current, follow secure development practices, add concise
-comments where logic is not obvious, and keep code and configuration files
-under 1000 lines and normal documentation under 2000 lines.
-Commits must not include AI co-author trailers.
-Future README rewrites should preserve this structure and only add new
-Ko-fi/support content when explicitly requested.
-Before pushing, check configured GitHub Actions and Dependabot status for
-failures, open update PRs, or open security alerts. As of 2026-07-24 there are
-no open security alerts; update PRs #3 (GitHub Actions) and #8 (`ruff`) remain
-open with green CI. Version `0.1.3` includes the dependency lock refresh made
-for patched `idna`, `requests`, and `urllib3` releases.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "os-download"
-version = "0.1.3"
+version = "0.1.4"
 description = "Find and download OS ISO images for Ubuntu, Fedora, openSUSE, Arch, Linux Mint, Rocky Linux, Windows 11, and more"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/os_download/__init__.py
+++ b/src/os_download/__init__.py
@@ -1,3 +1,3 @@
 """Find and download OS ISO images."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/uv.lock
+++ b/uv.lock
@@ -162,7 +162,7 @@ wheels = [
 
 [[package]]
 name = "os-download"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary
- removes internal maintainer instructions and dated dependency state from the public README
- keeps those rules in `HANDOFF.md` and `AGENTS.md`
- bumps the package to 0.1.4 so PyPI can receive corrected long-description metadata

## Verification
- `uv run ruff check`
- `uv run pytest -q` (74 passed, 2 skipped)
- `uv build`
- `uvx twine check dist/*`
- wheel and sdist metadata scanned for the removed internal-note phrases
- `git diff --check`
